### PR TITLE
Fixed DOS1 functions

### DIFF
--- a/engine/src/dos.c
+++ b/engine/src/dos.c
@@ -12,6 +12,9 @@
 //─────────────────────────────────────────────────────────────────────────────
 #include "dos.h"
 
+
+i8 g_DOS_LastError;
+	
 //=============================================================================
 // MSX-DOS 1
 //=============================================================================
@@ -26,9 +29,9 @@ i8 DOS_Open(fcb* stream)
 	stream; // HL
 __asm
 	// FCB pointer
-	ld		de, hl
+	ex		de, hl
 	// Open file
-	ld		c, #DOS_FOPEN
+	ld		c, #DOS_FUNC_FOPEN
 	call	BDOS
 	ld		(_g_DOS_LastError), a
 __endasm;
@@ -41,9 +44,9 @@ i8 DOS_Create(fcb* stream)
 	stream; // HL
 __asm
 	// FCB pointer
-	ld		de, hl
+	ex		de, hl
 	// Create file
-	ld		c, #DOS_FMAKE
+	ld		c, #DOS_FUNC_FMAKE
 	call	BDOS
 	ld		(_g_DOS_LastError), a
 __endasm;
@@ -56,9 +59,9 @@ i8 DOS_Close(fcb* stream)
 	stream; // HL
 __asm
 	// FCB pointer
-	ld		de, hl
+	ex		de, hl
 	// Close file
-	ld		c, #DOS_FCLOSE
+	ld		c, #DOS_FUNC_FCLOSE
 	call	BDOS
 	ld		(_g_DOS_LastError), a
 __endasm;
@@ -68,12 +71,12 @@ __endasm;
 // Set transfer address
 i8 DOS_SetTransferAddr(void* data)
 {
-	stream; // HL
+	data; // HL
 __asm
 	// FCB pointer
-	ld		de, hl
+	ex		de, hl
 	// 
-	ld		c, #DOS_SETDTA
+	ld		c, #DOS_FUNC_SETDTA
 	call	BDOS
 	ld		(_g_DOS_LastError),a
 __endasm;
@@ -86,9 +89,9 @@ i8 DOS_SequentialRead(fcb* stream)
 	stream; // HL
 __asm
 	// FCB pointer
-	ld		de, hl
+	ex		de, hl
 	// Sequential read
-	ld		c, #DOS_RDSEQ
+	ld		c, #DOS_FUNC_RDSEQ
 	call	BDOS
 	ld		(_g_DOS_LastError), a
 __endasm;
@@ -101,9 +104,9 @@ i8 DOS_SequentialWrite(fcb* stream)
 	stream; // HL
 __asm
 	// FCB pointer
-	ld		de, hl
+	ex		de, hl
 	// Sequential write
-	ld		c, #DOS_WRSEQ
+	ld		c, #DOS_FUNC_WRSEQ
 	call	BDOS
 	ld		(_g_DOS_LastError), a
 __endasm;

--- a/engine/src/dos.h
+++ b/engine/src/dos.h
@@ -15,6 +15,8 @@
 //─────────────────────────────────────────────────────────────────────────────
 #pragma once
 
+#include "core.h"
+
 // Bios calls that can be called directly from MSX-DOS
 //
 // RDSLT (000CH) - read value at specified address of specified slot


### PR DESCRIPTION
I fixed the DOS1 functions so they can be actually used now.

I created a small sample to test, it loads and displays a .GE5 file. Of course, allocating 30375 bytes on the heap is not ideal :P I could work around that but it would be better to have at least read random block added to MSXgl. I'll try to add those myself.


#include "msxgl.h"
#include "dos.h"
#include "memory.h"

fcb file;
u8 *data;

void main()
{
	VDP_SetMode(VDP_MODE_SCREEN5);
	VDP_SetColor(0);
	
	Mem_Set(0, &file, sizeof(fcb));
	Mem_Copy("TEST    GE5", &file.name, 11);
	
	DOS_Open(&file);
	
	data = Mem_HeapAlloc(30375);

	for (u16 i = 0; i < 30375; i+=128)
	{
		DOS_SetTransferAddr(&data[i]);
		DOS_SequentialRead(&file);
	}

	VDP_WriteVRAM_128K(&data[7], 0, 0, 256*212);
	VDP_SetPaletteEntry(0, data[0x07687] + (data[0x07687+1]<<8));
	VDP_SetPalette(&data[0x07687+2]);
	
	Mem_HeapFree(30375);
	DOS_Close(&file);
	
	while(!Keyboard_IsKeyPressed(KEY_ESC)) {}
}