### PR TITLE
Don't override default_config.cmd in built.bat

### DIFF
--- a/projects/samples/build.bat
+++ b/projects/samples/build.bat
@@ -119,15 +119,15 @@ set Verbose=0
 
 :: Emulator options (0=false, 1=true)
 set EmulMachine=0
-set Emul60Hz=0
-set EmulFullScreen=0
-set EmulMute=0
-set EmulDebug=0
-set EmulSCC=0
-set EmulMSXMusic=0
-set EmulMSXAudio=0
+REM set Emul60Hz=0
+REM set EmulFullScreen=0
+REM set EmulMute=0
+REM set EmulDebug=0
+REM set EmulSCC=0
+REM set EmulMSXMusic=0
+REM set EmulMSXAudio=0
 :: Emulator extra parameters to be add to command-line
-set EmulExtraParam=
+REM set EmulExtraParam=
 
 :: Check for sample specific parameters
 if exist %ProjName%.cmd call %ProjName%.cmd
@@ -135,12 +135,12 @@ if exist %ProjName%.cmd call %ProjName%.cmd
 ::*****************************************************************************
 :: BUILD STEPS
 ::*****************************************************************************
-set DoClean=0
-set DoCompile=1
-set DoMake=1
-set DoPackage=1
-set DoDeploy=1
-set DoRun=0
+REM set DoClean=0
+REM set DoCompile=1
+REM set DoMake=1
+REM set DoPackage=1
+REM set DoDeploy=1
+REM set DoRun=0
 
 ::*****************************************************************************
 :: START BUILD

--- a/projects/targets/build.bat
+++ b/projects/targets/build.bat
@@ -107,23 +107,23 @@ set Verbose=0
 ::*****************************************************************************
 
 :: Emulator options: 0 or 1
-set EmulMachine=1
-set Emul60Hz=0
-set EmulFullScreen=0
-set EmulMute=0
-set EmulDebug=0
+REM set EmulMachine=1
+REM set Emul60Hz=0
+REM set EmulFullScreen=0
+REM set EmulMute=0
+REM set EmulDebug=0
 :: Emulator extra parameters to be add to command-line
-set EmulExtraParam=
+REM set EmulExtraParam=
 
 ::*****************************************************************************
 :: BUILD STEPS
 ::*****************************************************************************
-set DoClean=0
-set DoCompile=1
-set DoMake=1
-set DoPackage=1
-set DoDeploy=1
-set DoRun=0
+REM set DoClean=0
+REM set DoCompile=1
+REM set DoMake=1
+REM set DoPackage=1
+REM set DoDeploy=1
+REM set DoRun=0
 
 ::*****************************************************************************
 :: START BUILD

--- a/projects/template/build.bat
+++ b/projects/template/build.bat
@@ -63,12 +63,12 @@ set Verbose=0
 ::*****************************************************************************
 :: BUILD STEPS
 ::*****************************************************************************
-set DoClean=0
-set DoCompile=1
-set DoMake=1
-set DoPackage=1
-set DoDeploy=1
-set DoRun=0
+REM set DoClean=0
+REM set DoCompile=1
+REM set DoMake=1
+REM set DoPackage=1
+REM set DoDeploy=1
+REM set DoRun=0
 
 ::*****************************************************************************
 :: START BUILD


### PR DESCRIPTION
## I'm submitting a ...

- [x] bug report
- [ ] feature request

## What is the current behavior?

There are three .bat : 
  * projects/samples/build.bat
  * projects/targets/build.bat
  * projects/template/build.bat

They all start with the same call to `call ..\default_config.cmd %0` for setting some default variables:
```
::*******************************************************************************
:: EMULATOR SETING
::*******************************************************************************

:: Emulator options: 0 or 1
set EmulMachine=1
set Emul60Hz=0
set EmulFullScreen=0
set EmulMute=0
set EmulDebug=0
set EmulSCC=0
set EmulMSXMusic=0
set EmulMSXAudio=0
:: Emulator extra parameters to be add to command-line
set EmulExtraParam=

::*******************************************************************************
:: BUILD STEPS
::*******************************************************************************
set DoClean=0
set DoCompile=1
set DoMake=1
set DoPackage=1
set DoDeploy=1
set DoRun=0
```

However, those default variable are redefined at the end of the three `build.bat`, making the call to `default_config.cmd` useless.

Changing `DoRun=1` in `default_config.cmd` has no effect because all the `build.bat` set `DoRun=0` at the end.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

  * Change `DoRun=1` in `default_config.cmd`
  * Open a command in `projects/samples`
  * Run `build.bat s_game`
  * The sample does not run

## What is the expected behavior?

  * The sample should run as `DoRun` is set to 1 in `default_config.cmd`

For this we should either add `REM` before all redefined variables or remove them in the `build.bat`.

## Please tell us about your environment:

Version: 16d84fc3d55b0b4d4dd8f07ca00fedf0b12a6210
OS: Windows
