### PR TITLE
( was unexpected at this time

### DIFF
--- a/engine/script/setup_emulator.cmd
+++ b/engine/script/setup_emulator.cmd
@@ -8,6 +8,11 @@
 
 for %%I in ("%Emulator%") do (set EmulatorName=%%~nI)
 
+if "%EmulatorName%"=="" (
+	echo %YELLOW%No emulator configured
+	exit /B 0
+)
+
 echo %BLUE%Starting %EmulatorName% emulator...%RESET%
 
 echo EmulMachine=%EmulMachine%


### PR DESCRIPTION
## I'm submitting a ...

- [x] bug report
- [ ] feature request

## What is the current behavior?

Running `build.bat` with `DoRun=1` without configuring the emulator path in `default_config.cmd` results in an obscure error message `( was unexpected at this time` for newcommers.

This happens because `setup_emulator.cmd` checks `if /I %EmulatorName%==openmsx`, but when `EmulatorName` is empty it is replaced with `if /I ==openmsx`, hence the `( was unexpected at this time` error message.

The script should check if `EmulatorName` is set beforehand and display a clear error message to the user.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

  * Change `DoRun=1` in `projects/samples/build.bat`
  * Make sure to have the default `set Emulator=` configuration in `default_config.cmd`
  * Open a command in `projects/samples`
  * Run `build.bat s_game`
  * The sample does not run and the script leaves you with `( was unexpected at this time`

## What is the expected behavior?

The script displays a clear error message of what happened.

## Please tell us about your environment:

Version: 16d84fc3d55b0b4d4dd8f07ca00fedf0b12a6210
OS: Windows
