### PR TITLE
compiling tools on GNU

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,12 @@
 # Declare files that will always have CRLF line endings on checkout.
-*.c text eol=crlf
-*.h text eol=crlf
-*.inc text eol=crlf
-*.inl text eol=crlf
-*.bat text eol=crlf
-*.cmd text eol=crlf
-*.py text eol=crlf
+#*.c text eol=crlf
+#*.h text eol=crlf
+#*.inc text eol=crlf
+#*.inl text eol=crlf
+#*.bat text eol=crlf
+#*.cmd text eol=crlf
+#*.py text eol=crlf
 
 # Denote all files that are truly binary and should not be modified.
 #* binary
+eol=auto


### PR DESCRIPTION
It's the job of the OS to decide whether text files should have CR, LF or both, so let's allow git to do its job and set this to auto. (files that need CR or LF in specific places are usually binary anyway).