### PR TITLE
Fix warning message

### DIFF
--- a/tools/MSXtk/src/MSXtk_export.h
+++ b/tools/MSXtk/src/MSXtk_export.h
@@ -45,6 +45,7 @@ public:
 
 	ExporterInterface() : TotalBytes(0), Config() {}
 	ExporterInterface(ExportConfig& cfg) : TotalBytes(0), Config(cfg) {}
+	virtual ~ExporterInterface() = default;
 
 	virtual void AddReturn() = 0;
 	virtual void AddComment(std::string comment = "") = 0;


### PR DESCRIPTION
Fix warning message deleting object of abstract class type '...' which has non-virtual destructor will cause undefined behaviour.