### PR TITLE
fix warning message

### DIFF
--- a/tools/MSXtk/src/Pletter.cpp
+++ b/tools/MSXtk/src/Pletter.cpp
@@ -317,7 +317,7 @@ void save(pakdata* p, unsigned q)
 			if (j < 128)
 				cout << "-j<128-";
 			j -= 128;
-			s.adddata(128 | j & 127);
+			s.adddata(128 | (j & 127));
 			switch (q)
 			{
 			case 6: s.addbit(j & 4096);


### PR DESCRIPTION
Solves pesky message
```
src/Pletter.cpp: In function ‘void save(pakdata*, unsigned int)’:
src/Pletter.cpp:320:43: warning: suggest parentheses around arithmetic in operand of ‘|’ [-Wparentheses]
  320 |                         s.adddata(128 | j & 127);
      |                                         ~~^~~~~

```