### PR TITLE
Command output should be 0 if successful

### DIFF
--- a/tools/MSXtk/src/MSXimg.cpp
+++ b/tools/MSXtk/src/MSXimg.cpp
@@ -990,6 +990,6 @@ int main(int argc, const char* argv[])
 	else
 		printf("Error: Fatal error!\n");
 
-	return bSucceed ? param.startAddr + size : 0;
+	return !bSucceed;
 }
 


### PR DESCRIPTION
Command output should be 0 if successful otherwise it triggers a fake error in Makefile and other build processes. For instance:
```
[pedro@fedora msx2]$ make clean
rm -rf out
[pedro@fedora msx2]$ make images
mkdir out
msxgl/tools/MSXtk/bin/MSXimg ./images/gameplay.png -pos 0 0 -size 256 192 -format bin -compress rle4 -bpc 4 -palette 16 -out out/gameplay.img
Succeed!
make: *** [Makefile:12: out/gameplay.img] Error 196
```