### PR TITLE
Make mglv optional

### DIFF
--- a/tools/MSXtk/src/MSXimg.cpp
+++ b/tools/MSXtk/src/MSXimg.cpp
@@ -140,7 +140,9 @@ void PrintHelp()
 	printf("    gm1           Generate all tables for Graphic mode 1 (Screen 1)\n");
 	printf("    gm2           Generate all tables for Graphic mode 2 or 3 (Screen 2 or 4)\n");
 	printf("    sprt          Export 16x16 sprites with specific block ordering\n");
+#ifdef MGLV
 	printf("    mglv          MGLV video format from multiple image\n");
+#endif
 	printf(" -pos x y         Start position in the input image\n");
 	printf(" -size x y        Width/height of a block to export (if 0, use image size)\n");
 	printf(" -num x y         Number of block to export (columns/rows number)\n");
@@ -245,6 +247,7 @@ void PrintHelp()
 	printf(" --noTilesName    Exclude name table (default: false)\n");
 	printf(" --noTilesPattern Exclude pattern table (default: false)\n");
 	printf(" --noTilesColor   Exclude color table (default: false)\n");
+#ifdef MGLV
 	printf("\n");
 	printf("MGLV options:\n");
 	printf(" -mglvHead x      File header\n");
@@ -257,6 +260,7 @@ void PrintHelp()
 	printf(" -mglvLoop        \n");
 	printf(" -mglvMinSkip x   Minimal size of skip chunk (default: 8)\n");
 	printf(" -mglvMinFill x   Minimal size of fill chunk (default: 60)\n");
+#endif
 }
 
 // Debug
@@ -538,8 +542,10 @@ int main(int argc, const char* argv[])
 				param.mode = MODE_GM2;
 			else if (MSX::StrEqual(argv[i], "sprt"))
 				param.mode = MODE_Sprite;
+#ifdef MGLV
 			else if (MSX::StrEqual(argv[i], "mglv"))
 				param.mode = MODE_MGLV;
+#endif
 			else if (MSX::StrEqual(argv[i], "txt") || MSX::StrEqual(argv[i], "sc0"))
 				param.mode = MODE_Text;
 		}
@@ -702,6 +708,7 @@ int main(int argc, const char* argv[])
 			else if (MSX::StrEqual(argv[i], "lanczos"))
 				param.scaleFilter = FILTER_Lanczos;
 		}
+#ifdef MGLV
 		else if (MSX::StrEqual(argv[i], "-mglvHead")) // File header
 		{
 			i++;
@@ -736,6 +743,7 @@ int main(int argc, const char* argv[])
 		{
 			param.mglvConfig.minFill = GetValue(argv[++i]);
 		}
+#endif
 	}
 
 	//-------------------------------------------------------------------------

--- a/tools/MSXtk/src/exporter.h
+++ b/tools/MSXtk/src/exporter.h
@@ -19,7 +19,9 @@
 // MSXi
 #include "MSXimg.h"
 #include "color.h"
+#ifdef MGLV
 #include "mglv.h"
+#endif
 
 #define BUFFER_SIZE 1024
 
@@ -71,6 +73,7 @@ struct Layer
 	std::vector<u32> colors;	///< Layer colors
 };
 
+#ifdef MGLV
 // Struct: ConfigMGLV
 // MGLV video player parameters
 struct ConfigMGLV
@@ -99,6 +102,7 @@ struct ConfigMGLV
 		minFill (MGLV_FILL_COUNT_MIN)
 	{}
 };
+#endif
 
 /// Exporter parameters
 struct ExportParameters
@@ -157,7 +161,9 @@ struct ExportParameters
 	bool flipH;
 	bool flipV;
 	f32 rotAngle;
+#ifdef MGLV
 	ConfigMGLV mglvConfig;
+#endif
 
 	ExportParameters()
 	{

--- a/tools/MSXtk/src/parser.cpp
+++ b/tools/MSXtk/src/parser.cpp
@@ -23,7 +23,9 @@
 #include "exporter.h"
 #include "image.h"
 #include "parser.h"
+#ifdef MGLV
 #include "mglv.h"
+#endif
 
 struct RLEHash
 {
@@ -2029,6 +2031,7 @@ bool ExportText(ExportParameters* param, ExporterInterface* exp)
 	return bSaved;
 }
 
+#ifdef MGLV
 //#############################################################################
 //
 // EXPORT MGLV
@@ -2394,6 +2397,7 @@ bool ExportMGLV(ExportParameters* param, ExporterInterface* exp)
 	bool bSaved = exp->Export();
 	return bSaved;
 }
+#endif // MGLV
 
 //-----------------------------------------------------------------------------
 // PARSE IMAGE
@@ -2411,6 +2415,8 @@ bool ParseImage(ExportParameters* param, ExporterInterface* exp)
 	case MODE_GM2:		return ExportGM2(param, exp);
 	case MODE_Sprite:	return ExportSprite(param, exp);
 	case MODE_Text:		return ExportText(param, exp);
+#ifdef MGLV
 	case MODE_MGLV:		return ExportMGLV(param, exp);
+#endif
 	};
 }


### PR DESCRIPTION
Allow user to compile MSXimg without mglv, which is not provided by default.