### PR TITLE
Macro to convert palette array entry to u16

### DIFF
--- a/engine/src/color.h
+++ b/engine/src/color.h
@@ -139,6 +139,7 @@ enum COLOR_BPC
 
 #define RGB16_From8B(r, g, b)	RGB16(((r) >> 5), ((g) >> 5), ((b) >> 5))
 #define RGB16_From32B(rgb)	RGB16_From8B(((u32)rgb >> 16) & 0xFF, ((rgb) >> 8) & 0xFF, (rgb) & 0xFF)
+#define RGB16_FromPal(pal, i)	(((u16*)(pal))[i])
 
 #define COLOR16_DEFAULT_0	RGB16(0, 0, 0)
 #define COLOR16_DEFAULT_1	RGB16(0, 0, 0)


### PR DESCRIPTION
Suppose you can't use `VDP_SetPalette` because your palette is incomplete. You can use this macro to solve this problem:
```C
    // Set color index i from 1 to 13
    for (int i = 0; i < 13; ++i) {
        VDP_SetPaletteEntry(i + 1, RGB16_FromPal(palette, i));
```