### PR TITLE
DOS '\r\n' at the end of file causes error in UNIX

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 #*.inl text eol=crlf
 *.bat text eol=crlf
 *.cmd text eol=crlf
+*.sh text eol=lf
 #*.py text eol=crlf
 
 #-- Denote all files that are truly binary and should not be modified.


### PR DESCRIPTION
build.sh out of the box:
```
./build.sh
bash: ./build.sh: cannot execute: required file not found
```