### PR TITLE
Fix buffer overflow "spawnSync /bin/sh ENOBUFS"

### DIFF
--- a/engine/script/js/build.js
+++ b/engine/script/js/build.js
@@ -1137,6 +1137,6 @@ if (DoRun)
 	{
 		require("./setup_emulator.js");
 
-		util.exec(`"${Emulator}" ${EmulatorArgs}`);
+		util.execSync(`"${Emulator}" ${EmulatorArgs}`);
 	}
 }


### PR DESCRIPTION
Using execSync instead of exec will send output to stdout right away instead of collecting it in a buffer. If the emulator is configured to send lots of debug messages to the buffer, it will fill up rapidly and cause an exception that crashes the emulator (ENOBUFS).