### PR TITLE
Fix parameter precedence in vdp macros

### DIFF
--- a/engine/src/vdp.h
+++ b/engine/src/vdp.h
@@ -165,13 +165,13 @@ extern u8 g_SpriteColorHigh;		// Address of the Sprite Color Table
 	#define VADDR_LO(a)			(a)
 	#define VADDR_HI(a)			0
 	#define VADDR_GET(lo, hi)	(lo)
-	#define VADDR_14_CODE(a)	a
+	#define VADDR_14_CODE(a)	(a)
 	#define VADDR_17_CODE(a)
 #else // if (VDP_VRAM_ADDR == VDP_VRAM_ADDR_17)
 	#define VADDR				u32
 	#define VADDR_LO(a)			(u16)(a)
-	#define VADDR_HI(a)			(u16)(a >> 16)
-	#define VADDR_GET(lo, hi)	((u32)(lo) | ((u32)hi << 16))
+	#define VADDR_HI(a)			(((u16)a) >> 16)
+	#define VADDR_GET(lo, hi)	(((u32)hi) << 16 | ((u32)lo))
 	#define VADDR_14_CODE(a)
 	#define VADDR_17_CODE(a)	a
 #endif
@@ -219,10 +219,10 @@ extern u8 g_SpriteColorHigh;		// Address of the Sprite Color Table
 //.............................................................................
 // Helper macros
 
-#define VRAM16b(a)				(u16)((u32)(a >> 4))
-#define VRAM17b(a)				(u16)((u32)(a >> 1))
-#define Addr20bTo16b(a)			(u16)((u32)(a >> 4))	// Convert 20-bits (V)RAM address into 16-bits with bit shifting
-#define Addr17bTo16b(a)			(u16)((u32)(a >> 1))	// Convert 17-bits (V)RAM address into 16-bits with bit shifting
+#define VRAM16b(a)				((u16)((u32)(a) >> 4))
+#define VRAM17b(a)				((u16)((u32)(a) >> 1))
+#define Addr20bTo16b(a)			((u16)((u32)(a) >> 4))	// Convert 20-bits (V)RAM address into 16-bits with bit shifting
+#define Addr17bTo16b(a)			((u16)((u32)(a) >> 1))	// Convert 17-bits (V)RAM address into 16-bits with bit shifting
 
 // #define REGSAV(a)				#(_g_VDP_REGSAV+a)
 


### PR DESCRIPTION
Every parameter should be isolated with parenthesis. This following code exposes the problem:
```
#include <stdio.h>
#include <stdint.h>

#define u16 uint16_t
#define u32 uint32_t

#define VADDR_HI(a)			(u16)(a >> 16)			// wrong
#define VADDR_HI2(a)		(u16)((a) >> 16)		// correct

#define VADDR_GET(lo, hi)	((u32)(lo) | ((u32)hi << 16))	// wrong
#define VADDR_GET2(lo, hi)	(((u32)hi) << 16 | ((u32)lo))	// correct

#define VRAM16b(a)			(u16)((u32)(a >> 4))		// wrong
#define VRAM16b2(a)			(u16)(((u32)a) >> 4)		// correct

#define VRAM17b(a)			(u16)((u32)(a >> 1))		// wrong
#define VRAM17b2(a)			(u16)(((u32)a) >> 1)		// correct


int main()
{
	printf("wrong: %i\n", VADDR_HI(1 | 1));
	printf("correct: %i\n\n", VADDR_HI2(1 | 1));

	printf("wrong: %i\n", VADDR_GET(0, 1 | 1));
	printf("correct: %i\n\n", VADDR_GET2(0, 1 | 1));

	printf("wrong: %i\n", VRAM16b(0x1000 | 0x2000));
	printf("correct: %i\n\n", VRAM16b2(0x1000 | 0x2000));

	printf("wrong: %i\n", VRAM17b(0x1000 | 0x2000));
	printf("correct: %i\n", VRAM17b2(0x1000 | 0x2000));

	return 0;
}
```
result:
```
wrong: 1
correct: 0

wrong: 65537
correct: 65536

wrong: 4608
correct: 768

wrong: 4096
correct: 6144
```