### PR TITLE
[CORE] Error for type casts in version preprocessor macros

### DIFF
--- a/engine/src/core.h
+++ b/engine/src/core.h
@@ -8,9 +8,9 @@
 #pragma once
 
 // Library version
-#define VERSION_MAJOR				(u16)1		// 4-bits (0-15)
-#define VERSION_MINOR				(u16)3		// 6-bits (0-63)
-#define VERSION_PATCH				(u16)7		// 6-bits (0-63)
+#define VERSION_MAJOR				1		// 4-bits (0-15)
+#define VERSION_MINOR				3		// 6-bits (0-63)
+#define VERSION_PATCH				7		// 6-bits (0-63)
 
 // Macro: VERSION
 // Combines major, minor, and patch versions into a single version number.


### PR DESCRIPTION
The C preprocessor doesn't understand type casts, so checking for the MSXgl version causes the compilation to fail with the error reported below. Removing the type casts from the `VERSION_{}` macros allows to correclty check for MSXgl version:

```
Compiling ./chronorunner.c using SDCC C compiler...
Execute: [...]
./chronorunner.c:6:5: error: missing binary operator before token "1"
Command failed: [...]
Exit code: 1
Error: Error: Compile error! Code: 1
```

```c
#if MSXGL_VERSION < VERSION(1, 3, 7)
#error Please build with MSXgl >=1.3.7
#endif
```