### PR TITLE
Fix typos

### DIFF
--- a/engine/src/debug.c
+++ b/engine/src/debug.c
@@ -75,7 +75,7 @@ void DEBUG_BREAK()
 }
 
 //-----------------------------------------------------------------------------
-// Conditionnal break
+// Conditional break
 void DEBUG_ASSERT(bool a)
 {	
 	if (!(a))
@@ -110,7 +110,7 @@ void DEBUG_LOGNUM(const c8* msg, u8 num)
 }
 
 //-----------------------------------------------------------------------------
-// Display debug formated message
+// Display debug formatted message
 void DEBUG_PRINT(const c8* format, ...)
 {
 #if (DEBUG_TOOL == DEBUG_OPENMSX_P)
@@ -184,7 +184,7 @@ __endasm;
 }
 
 //-----------------------------------------------------------------------------
-// Conditionnal break
+// Conditional break
 void DEBUG_ASSERT(bool a)
 {
 	if (!(a))
@@ -214,7 +214,7 @@ void DEBUG_LOGNUM(const c8* msg, u8 num)
 }
 
 //-----------------------------------------------------------------------------
-// Display debug formated message
+// Display debug formatted message
 // from SMSlib - C programming library for the SMS/GG (part of devkitSMS - github.com/sverx/devkitSMS)
 // https://github.com/sverx/devkitSMS/blob/master/SMSlib/src/SMSlib_debug.c
 void DEBUG_PRINT(const c8 *format, ...) __NAKED __PRESERVES(a, b, c, iyh, iyl)

--- a/engine/src/debug.h
+++ b/engine/src/debug.h
@@ -38,10 +38,10 @@
 	void DEBUG_BREAK();
 
 	// Function: DEBUG_ASSERT
-	// Conditionnal break.
+	// Conditional break.
 	//
 	// Parameters:
-	//   a - Instructions to evialuate. A 'false' result will trigger a break.
+	//   a - Instructions to evaluate. A 'false' result will trigger a break.
 	//
 	// Notes:
 	// - [Emulicious] You need the "Break on ld b, b instruction" exception to be activated.
@@ -52,23 +52,23 @@
 	// Display debug message (and return to next line).
 	//
 	// Parameters:
-	//   msg - Null-terminated string with message to display
+	//   msg - Nul-terminated string with message to display
 	void DEBUG_LOG(const c8* msg);
 
 	// Function: DEBUG_LOGNUM
 	// Display debug message and a 8-bits value (and return to next line).
 	//
 	// Parameters:
-	//   msg - Null-terminated string with numer name
+	//   msg - Nul-terminated string with numer name
 	//   num - 8-bit number value
 	void DEBUG_LOGNUM(const c8* msg, u8 num);
 
 	// Function: DEBUG_PRINT
-	// Display debug formated message.
+	// Display debug formatted message.
 	// No new line is added at the end of the message.
 	//
 	// Parameters:
-	//   format - Null-terminated string with format specifiers
+	//   format - Nul-terminated string with format specifiers
 	//
 	// Notes:
 	// - [Emulicious] Supported format specifiers: https://www.tutorialspoint.com/format-specifiers-in-c
@@ -85,7 +85,7 @@
 	// Force a break point
 	#define DEBUG_BREAK()
 
-	// Conditionnal break
+	// Conditional break
 	#define DEBUG_ASSERT(a)
 
 	// Display debug message
@@ -94,7 +94,7 @@
 	// Display debug message and a 8-bits value
 	#define DEBUG_LOGNUM(msg, num)
 
-	// Display debug formated message
+	// Display debug formatted message
 	#define DEBUG_PRINT(...)
 
 #endif
@@ -194,7 +194,7 @@
 	// Parameters:
 	//   level - Minimal level to display the section
 	//   section - Section identifier
-	//   msg - Null-terminated string with section name
+	//   msg - Nul-terminated string with section name
 	inline void PROFILE_SECTION_START(u8 level, u8 section, const c8* msg) { level; section; msg; }
 
 	// Function: PROFILE_SECTION_END
@@ -203,7 +203,7 @@
 	// Parameters:
 	//   level - Minimal level to display the section
 	//   section - Section identifier
-	//   msg - Null-terminated string with section name
+	//   msg - Nul-terminated string with section name
 	inline void PROFILE_SECTION_END(u8 level, u8 section, const c8* msg) { level; section; msg; }
 
 #endif

--- a/engine/src/print.c
+++ b/engine/src/print.c
@@ -1279,7 +1279,7 @@ void Print_DrawInt(i16 value)
 #if (PRINT_USE_FORMAT)
 
 //-----------------------------------------------------------------------------
-// Print a formated string with a variable number of parameters
+// Print a formatted string with a variable number of parameters
 void Print_DrawFormat(const c8* format, ...)
 {
 	// @todo To be replaced by String_Format() + Print_DrawText()

--- a/engine/src/print.h
+++ b/engine/src/print.h
@@ -460,7 +460,7 @@ inline void Print_Return()
 //.............................................................................
 #if (PRINT_USE_FORMAT)
 // Function: Print_DrawFormat
-// Print a formated string with a variable number of parameters.
+// Print a formatted string with a variable number of parameters.
 // This function requires PRINT_USE_FORMAT compile option to be set to TRUE.
 //
 // Parameters:


### PR DESCRIPTION
"NULL" is the address of an invalid pointer, while "NUL" is the name of the ASCII character with value 0.