### PR TITLE
DEBUG_ASSERT is more helpful as macro than as a function

### DIFF
--- a/engine/src/debug.c
+++ b/engine/src/debug.c
@@ -75,14 +75,6 @@ void DEBUG_BREAK()
 }
 
 //-----------------------------------------------------------------------------
-// Conditional break
-void DEBUG_ASSERT(bool a)
-{	
-	if (!(a))
-		DEBUG_BREAK();
-}
-
-//-----------------------------------------------------------------------------
 // Display debug message
 void DEBUG_LOG(const c8* msg)
 {

--- a/engine/src/debug.h
+++ b/engine/src/debug.h
@@ -46,7 +46,8 @@
 	// Notes:
 	// - [Emulicious] You need the "Break on ld b, b instruction" exception to be activated.
 	// - [openMSX] You need the "tools/script/openMSX/debugger_pvm.tcl" script to be loaded to use this function.
-	void DEBUG_ASSERT(bool a);
+	#define DEBUG_ASSERT(cond) \
+		do { if (!cond) { DEBUG_PRINT("assert failed on \"" #cond "\" from file %s: %i\n", __FILE__, __LINE__); DEBUG_BREAK(); } } while(0) 
 
 	// Function: DEBUG_LOG
 	// Display debug message (and return to next line).


### PR DESCRIPTION
DEBUG_ASSERT should always be a macro, because it gets access to special macro features, like the code of the condition that failed and the `__FILE__` and `__LINE__` keywords that points directly to the file and line number where the assert was triggered and that is the purpose of the macro existence in the first place.

No useful output is possible with DEBUG_ASSERT as a function, but as a macro you get this kind of error message:
```
assert failed on "get_map_address() != NULL" from file ./caterpuzzle.c: 602
```
from this line of code:
```
DEBUG_ASSERT(get_map_address() != NULL);
```

Attention: #83 should be merged before this PR.