### PR TITLE
Fixed String_Format() from printing garbage numbers with placeholders

### DIFF
--- a/engine/src/debug.c
+++ b/engine/src/debug.c
@@ -127,7 +127,7 @@ void DEBUG_PRINT(const c8* format, ...)
 
 	va_list args;
 	va_start(args, format);
-  	String_Format(g_DebugBuffer, format, &args);
+	String_Format_va(g_DebugBuffer, format, args);
 	va_end(args);
 
 	DEBUG_LOG(g_DebugBuffer);

--- a/engine/src/string.c
+++ b/engine/src/string.c
@@ -132,11 +132,9 @@ __endasm;
 //   dest - Destination string buffer (must big enough to contain the whole string)
 //   format - Formating string
 //   ... - Variable number of parameter (depends on the Formating string)
-void String_Format(c8* dest, const c8* format, ...)
-{
-	va_list args;
-	va_start(args, format);
 
+void String_Format_va(c8* dest, const c8* format, va_list args)
+{
 	c8 str[16];
 	const c8* ptr = format;
 	while (*ptr != 0)
@@ -295,7 +293,13 @@ void String_Format(c8* dest, const c8* format, ...)
 		ptr++;
 	}
 	*dest = 0;
+}
 
+void String_Format(c8* dest, const c8* format, ...)
+{
+	va_list args;
+	va_start(args, format);
+	String_Format_va(dest, format, args);
 	va_end(args);
 }
 #endif // (STRING_USE_FORMAT)

--- a/engine/src/string.h
+++ b/engine/src/string.h
@@ -172,5 +172,6 @@ void String_FromUInt16(u16 value, c8* string);
 //   dest - Destination string buffer (must big enough to contain the whole string)
 //   format - Formating string
 //   ... - Variable number of parameter (must match the Formating string)
+void String_Format_va(c8* dest, const c8* format, va_list args);
 void String_Format(c8* dest, const c8* format, ...);
 #endif


### PR DESCRIPTION
The "String_Format()" function does not work when using any placeholder parameters to print dynamic content (e.g. "%d" for integer values). This is caused by wrong usage of the variable parameter convention and conversion via the va_list type.

The fix introduces a new function "String_Format_va()" to fix this, and a modification to the function "String_Format()" and "DEBUG_PRINT()" to call the new function, passing the parameters properly.