### PR TITLE
Feature: Allow projects to reside outside MSXgl\projects dir

### DIFF
--- a/projects/samples/build.bat
+++ b/projects/samples/build.bat
@@ -7,6 +7,10 @@
 ::─────────────────────────────────────────────────────────────────────────────
 @echo off
 
+IF NOT DEFINED MSXGL_PATH (
+    set MSXGL_PATH=..\..
+)
+
 cls
 
-..\..\tools\build\Node\node.exe ..\..\engine\script\js\build.js projname=%~n1 %2 %3 %4 %5 %6 %7 %8 %9
+%MSXGL_PATH%\tools\build\Node\node.exe %MSXGL_PATH%\engine\script\js\build.js projname=%~n1 %2 %3 %4 %5 %6 %7 %8 %9

--- a/projects/targets/build.bat
+++ b/projects/targets/build.bat
@@ -11,6 +11,10 @@
 :: PROJECT SETTINGS
 ::*****************************************************************************
 
+IF NOT DEFINED MSXGL_PATH (
+    set MSXGL_PATH=..\..
+)
+
 set ARGS=target^=%1 projname^=s_target
 
 :: Project name (will be use for output filename)
@@ -29,4 +33,4 @@ if "%4" == "RAMISR" set ARGS=%ARGS% ramisr
 if "%4" == "RAMSEG" set ARGS=%ARGS% ramseg
 
 cls
-..\..\tools\build\Node\node.exe ..\..\engine\script\js\build.js %ARGS% %5 %6 %7 %8 %9
+%MSXGL_PATH%\tools\build\Node\node.exe %MSXGL_PATH%\engine\script\js\build.js %ARGS% %5 %6 %7 %8 %9

--- a/projects/template/build.bat
+++ b/projects/template/build.bat
@@ -7,6 +7,10 @@
 ::────────────────────────────────────────────────────────────────────
 @echo off
 
+IF NOT DEFINED MSXGL_PATH (
+    set MSXGL_PATH=..\..
+)
+
 cls
 
-..\..\tools\build\Node\node.exe ..\..\engine\script\js\build.js %1 %2 %3 %4 %5 %6 %7 %8 %9
+%MSXGL_PATH%\tools\build\Node\node.exe %MSXGL_PATH%\engine\script\js\build.js %1 %2 %3 %4 %5 %6 %7 %8 %9

--- a/projects/template_msx2/build.bat
+++ b/projects/template_msx2/build.bat
@@ -7,6 +7,10 @@
 ::────────────────────────────────────────────────────────────────────
 @echo off
 
+IF NOT DEFINED MSXGL_PATH (
+    set MSXGL_PATH=..\..
+)
+
 cls
 
-..\..\tools\build\Node\node.exe ..\..\engine\script\js\build.js %1 %2 %3 %4 %5 %6 %7 %8 %9
+%MSXGL_PATH%\tools\build\Node\node.exe %MSXGL_PATH%\engine\script\js\build.js %1 %2 %3 %4 %5 %6 %7 %8 %9


### PR DESCRIPTION
This update enables projects to build correctly even when they are located outside, or deeper within, the _MSXgl\projects_ directory structure.

The current build process relies on hard‑coded relative paths (`..\..`) to locate `node.exe` and `build.js`. This change introduces an optional environment variable, **MSXGL_PATH**, which allows developers to explicitly specify the MSXgl installation directory.

When **MSXGL_PATH** is defined, all `build.bat` scripts use it as the base path. When it is not defined, the scripts fall back to the existing `..\..` relative paths, ensuring full backward compatibility for existing projects.