### PR TITLE
Fix types of keyboard buffer pointers

### DIFF
--- a/engine/src/bios_var.h
+++ b/engine/src/bios_var.h
@@ -218,10 +218,10 @@ const u8 __at(M_SCNCNT) g_SCNCNT;
 const u8 __at(M_REPCNT) g_REPCNT;
 
 #define M_PUTPNT	0xF3F8	// Address in the keyboard buffer where a character will be written
-const u16 __at(M_PUTPNT) g_PUTPNT;
+volatile char *__at(M_PUTPNT) g_PUTPNT;
 
 #define M_GETPNT	0xF3FA	// Address in the keyboard buffer where the next character is read
-const u16 __at(M_GETPNT) g_GETPNT;
+volatile const char *__at(M_GETPNT) g_GETPNT;
 
 //-----------------------------------------------------------------------------
 // Parameters For Cassette


### PR DESCRIPTION
This fixes the types for the system's keyboard buffer pointers (g_PUTPNT, g_GETPNT), so they can be used in a more natural way in C code to check whether a key is in the buffer, clear the buffer, read from the buffer and fill the buffer, for example:

```
bool kb_IsKeyInBuffer()
{
	return g_GETPNT != g_PUTPNT;
}

void kb_ClearBuffer()
{
	g_GETPNT = g_PUTPNT;
}
```